### PR TITLE
Allow user control over whether plot is displayed when calling `plate_plot()`

### DIFF
--- a/R/plate_plot.R
+++ b/R/plate_plot.R
@@ -135,7 +135,11 @@ plate_plot <- function(data,
   }
 
   if (missing(scale)) {
-    scale <- min((graphics::par("fin")[1] / 5.572917), (graphics::par("fin")[2] / 3.177083))
+    if (display_plot) {
+      scale <- min((graphics::par("fin")[1] / 5.572917), (graphics::par("fin")[2] / 3.177083))
+    } else {
+      scale <- 7 / 5.572917
+    }
   }
 
   if (!silent) {
@@ -525,9 +529,9 @@ plate_plot <- function(data,
       panel.border = ggplot2::element_rect(linewidth = stroke_width)
     )
 
-  if (display_plot) {
-    plot
-  }
+  # if (display_plot) {
+  #   plot
+  # }
 
   return(plot)
 }

--- a/R/plate_plot.R
+++ b/R/plate_plot.R
@@ -38,7 +38,7 @@
 #' @param display_plot a logical value that specifies if the function should display the layout plot using a graphics device.
 #' Default is `TRUE` meaning that the plot will be displayed.
 #'
-#' @return A plate layout plot.
+#' @return A plate layout plot as a ggplot object.
 #' @importFrom graphics par
 #' @importFrom rlang .data :=
 #' @importFrom stringr str_extract
@@ -528,4 +528,6 @@ plate_plot <- function(data,
   if (display_plot) {
     plot
   }
+
+  return(plot)
 }

--- a/R/plate_plot.R
+++ b/R/plate_plot.R
@@ -35,6 +35,8 @@
 #' @param scale a numeric value that scales point sizes and labels of the plot. If not provided, the plot uses the device size
 #' to find the optimal scaling factor for the output, however, this might be slightly off (e.g. due to number of labels) and
 #' can be manually adjusted with this argument.
+#' @param display_plot a logical value that specifies if the function should display the layout plot using a graphics device.
+#' Default is `TRUE` meaning that the plot will be displayed.
 #'
 #' @return A plate layout plot.
 #' @importFrom graphics par
@@ -126,7 +128,8 @@ plate_plot <- function(data,
                        legend_n_row,
                        label_size,
                        silent = TRUE,
-                       scale) {
+                       scale,
+                       display_plot = TRUE) {
   if (!plate_size %in% c(6, 12, 24, 48, 96, 384)) {
     stop("Selected plate_size not available!")
   }
@@ -522,5 +525,7 @@ plate_plot <- function(data,
       panel.border = ggplot2::element_rect(linewidth = stroke_width)
     )
 
-  plot
+  if (display_plot) {
+    plot
+  }
 }

--- a/R/plate_plot.R
+++ b/R/plate_plot.R
@@ -135,11 +135,7 @@ plate_plot <- function(data,
   }
 
   if (missing(scale)) {
-    if (display_plot) {
-      scale <- min((graphics::par("fin")[1] / 5.572917), (graphics::par("fin")[2] / 3.177083))
-    } else {
-      scale <- 7 / 5.572917
-    }
+    scale <- min((graphics::par("fin")[1] / 5.572917), (graphics::par("fin")[2] / 3.177083))
   }
 
   if (!silent) {

--- a/R/plate_plot.R
+++ b/R/plate_plot.R
@@ -485,13 +485,13 @@ plate_plot <- function(data,
       y = ""
     ) +
     {
-      if (!missing(label)) ggplot2::geom_text(ggplot2::aes(x = col, 
-                                                           y = .data$row_num, 
+      if (!missing(label)) ggplot2::geom_text(ggplot2::aes(x = col,
+                                                           y = .data$row_num,
                                                            label = paste0(format(
-                                                             {{ label }}, 
+                                                             {{ label }},
                                                              drop0Trailing = F)
-                                                             )), 
-                                              colour = data_prep$label_colours, 
+                                                             )),
+                                              colour = data_prep$label_colours,
                                               size = label_size_scaled)
     } +
     ggplot2::theme_bw() +
@@ -529,9 +529,9 @@ plate_plot <- function(data,
       panel.border = ggplot2::element_rect(linewidth = stroke_width)
     )
 
-  # if (display_plot) {
-  #   plot
-  # }
+  if (display_plot) {
+    plot
+  }
 
   return(plot)
 }

--- a/man/plate_plot.Rd
+++ b/man/plate_plot.Rd
@@ -19,7 +19,8 @@ plate_plot(
   legend_n_row,
   label_size,
   silent = TRUE,
-  scale
+  scale,
+  display_plot = TRUE
 )
 }
 \arguments{
@@ -69,6 +70,9 @@ has these dimensions the scaling factor is 1.}
 \item{scale}{a numeric value that scales point sizes and labels of the plot. If not provided, the plot uses the device size
 to find the optimal scaling factor for the output, however, this might be slightly off (e.g. due to number of labels) and
 can be manually adjusted with this argument.}
+
+\item{display_plot}{a logical value that specifies if the function should display the layout plot using a graphics device.
+Default is \code{TRUE} meaning that the plot will be displayed.}
 }
 \value{
 A plate layout plot.

--- a/man/plate_plot.Rd
+++ b/man/plate_plot.Rd
@@ -75,7 +75,7 @@ can be manually adjusted with this argument.}
 Default is \code{TRUE} meaning that the plot will be displayed.}
 }
 \value{
-A plate layout plot.
+A plate layout plot as a ggplot object.
 }
 \description{
 Plots a culture plate or microplate in the desired format. Both continuous as well as discrete values can be displayed


### PR DESCRIPTION
When using the `plate_plot()` function to plot many layouts at once (e.g. using `purrr::map()`) and later saving them to files directly, having the function open a graphics device for each plot is unnecessary.
I implemented an additional parameter currently called `display_plot` that allows the user to control whether the plot is displayed when the function is called. It also controls how the scale is set since `graphics::par()` will open a graphics device. Finally, I added an explicit `return(plot)` statement.

Any thoughts?